### PR TITLE
Saving pictures in local storage

### DIFF
--- a/src/components/Media.tsx
+++ b/src/components/Media.tsx
@@ -7,7 +7,8 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../redux/store";
 import { addFavourite } from "../redux/favouriteSlice";
 import { styled } from "@mui/system";
 import Snackbar from "@mui/material/Snackbar";
@@ -25,7 +26,9 @@ const Media: React.FC = () => {
     title: "",
   });
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [duplicateAlertOpen, setDuplicateAlertOpen] = useState(false);
   const dispatch = useDispatch();
+  const favourites = useSelector((state: RootState) => state.favourites.items);
 
   useEffect(() => {
     fetchMedia();
@@ -44,12 +47,22 @@ const Media: React.FC = () => {
   };
 
   const handleSave = () => {
-    dispatch(addFavourite(media));
-    setSnackbarOpen(true);
+    const isDuplicate = favourites.some((fav) => fav.url === media.url);
+
+    if (isDuplicate) {
+      setDuplicateAlertOpen(true);
+    } else {
+      dispatch(addFavourite(media));
+      setSnackbarOpen(true);
+    }
   };
 
   const handleSnackbarClose = () => {
     setSnackbarOpen(false);
+  };
+
+  const handleDuplicateAlertClose = () => {
+    setDuplicateAlertOpen(false);
   };
 
   return (
@@ -86,6 +99,21 @@ const Media: React.FC = () => {
           severity="success"
         >
           The media has been saved to favourites.
+        </MuiAlert>
+      </Snackbar>
+
+      <Snackbar
+        open={duplicateAlertOpen}
+        autoHideDuration={4000}
+        onClose={handleDuplicateAlertClose}
+      >
+        <MuiAlert
+          elevation={6}
+          variant="filled"
+          onClose={handleDuplicateAlertClose}
+          severity="warning"
+        >
+          You have already saved this media.
         </MuiAlert>
       </Snackbar>
     </StyledCard>

--- a/src/pages/Favourites.tsx
+++ b/src/pages/Favourites.tsx
@@ -1,10 +1,23 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../redux/store";
-import { Card, CardMedia, CardContent, Typography, Grid } from "@mui/material";
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  Grid,
+  Button,
+} from "@mui/material";
+import { removeFavourite } from "../redux/favouriteSlice";
 
 const Favourites: React.FC = () => {
   const favourites = useSelector((state: RootState) => state.favourites.items);
+  const dispatch = useDispatch();
+
+  const handleRemove = (url: string) => {
+    dispatch(removeFavourite(url));
+  };
 
   return (
     <Grid container spacing={2}>
@@ -21,6 +34,13 @@ const Favourites: React.FC = () => {
             />
             <CardContent>
               <Typography variant="h5">{fav.title}</Typography>
+              <Button
+                variant="contained"
+                color="secondary"
+                onClick={() => handleRemove(fav.url)}
+              >
+                Delete
+              </Button>
             </CardContent>
           </Card>
         </Grid>

--- a/src/redux/favouriteSlice/index.ts
+++ b/src/redux/favouriteSlice/index.ts
@@ -1,17 +1,14 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-interface Favourite {
-  url: string;
-  title: string;
-}
-
-interface FavouritesState {
-  items: Favourite[];
-}
+import { Favourite, FavouritesState } from "./types";
 
 const initialState: FavouritesState = {
   items: [],
 };
+
+const savedMedia = localStorage.getItem("savedMedia");
+if (savedMedia) {
+  initialState.items = JSON.parse(savedMedia);
+}
 
 const favouritesSlice = createSlice({
   name: "favourites",
@@ -19,9 +16,18 @@ const favouritesSlice = createSlice({
   reducers: {
     addFavourite(state, action: PayloadAction<Favourite>) {
       state.items.push(action.payload);
+      updateLocalStorage(state.items);
+    },
+    removeFavourite(state, action: PayloadAction<string>) {
+      state.items = state.items.filter((item) => item.url !== action.payload);
+      updateLocalStorage(state.items);
     },
   },
 });
 
-export const { addFavourite } = favouritesSlice.actions;
+const updateLocalStorage = (items: Favourite[]) => {
+  localStorage.setItem("savedMedia", JSON.stringify(items));
+};
+
+export const { addFavourite, removeFavourite } = favouritesSlice.actions;
 export default favouritesSlice.reducer;

--- a/src/redux/favouriteSlice/types.ts
+++ b/src/redux/favouriteSlice/types.ts
@@ -1,4 +1,4 @@
-type Favourite = {
+export type Favourite = {
   date?: string;
   explanation?: string;
   media_type?: string;


### PR DESCRIPTION
What changed:

- Added logic to save pictures in the favorites tab using local storage to persist the user's favorites even after refreshing the application
- Implemented a check to prevent duplicate pictures from being added to the favorites tab
- Added an alert to notify the user when they attempt to add a duplicate picture to the favorites tab

Screenshot (if applicable):
![image](https://github.com/AdamKukiela/nasa-app/assets/92393623/6bb0f0a8-b2ae-46dd-9155-f3f09e7fcfde)
